### PR TITLE
Use data types when setting callbacks

### DIFF
--- a/rmw/include/rmw/event.h
+++ b/rmw/include/rmw/event.h
@@ -29,35 +29,6 @@ extern "C"
 #include "rmw/ret_types.h"
 #include "rmw/visibility_control.h"
 
-/// Define publisher/subscription events
-typedef enum rmw_event_type_t
-{
-  // subscription events
-  RMW_EVENT_LIVELINESS_CHANGED,
-  RMW_EVENT_REQUESTED_DEADLINE_MISSED,
-  RMW_EVENT_REQUESTED_QOS_INCOMPATIBLE,
-  RMW_EVENT_MESSAGE_LOST,
-
-  // publisher events
-  RMW_EVENT_LIVELINESS_LOST,
-  RMW_EVENT_OFFERED_DEADLINE_MISSED,
-  RMW_EVENT_OFFERED_QOS_INCOMPATIBLE,
-
-  // sentinel value
-  RMW_EVENT_INVALID
-} rmw_event_type_t;
-
-/// Encapsulate the RMW event implementation, data, and type.
-typedef struct RMW_PUBLIC_TYPE rmw_event_t
-{
-  /// Implementation identifier, used to ensure two different implementations are not being mixed.
-  const char * implementation_identifier;
-  /// Data specific to this event type from either the publisher or subscriber.
-  void * data;
-  /// The event type that occurred.
-  rmw_event_type_t event_type;
-} rmw_event_t;
-
 /// Return a zero initialized event structure.
 RMW_PUBLIC
 RMW_WARN_UNUSED

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -2796,7 +2796,7 @@ rmw_subscription_set_events_executor_callback(
   const void * executor_context,
   EventsExecutorCallback executor_callback,
   const void * subscription_handle,
-  void * rmw_subscription);
+  rmw_subscription_t * rmw_subscription);
 
 /// Add documentation
 RMW_PUBLIC
@@ -2806,7 +2806,7 @@ rmw_service_set_events_executor_callback(
   const void * executor_context,
   EventsExecutorCallback executor_callback,
   const void * service_handle,
-  void * rmw_service);
+  rmw_service_t * rmw_service);
 
 /// Add documentation
 RMW_PUBLIC
@@ -2816,7 +2816,7 @@ rmw_client_set_events_executor_callback(
   const void * executor_context,
   EventsExecutorCallback executor_callback,
   const void * client_handle,
-  void * rmw_client);
+  rmw_client_t * rmw_client);
 
 /// Add documentation
 RMW_PUBLIC
@@ -2826,7 +2826,7 @@ rmw_guard_condition_set_events_executor_callback(
   const void * executor_context,
   EventsExecutorCallback executor_callback,
   const void * guard_condition_handle,
-  void * rmw_guard_condition,
+  rmw_guard_condition_t * rmw_guard_condition,
   bool use_previous_events);
 
 /// Add documentation
@@ -2837,7 +2837,7 @@ rmw_event_set_events_executor_callback(
   const void * executor_context,
   EventsExecutorCallback executor_callback,
   const void * event_handle,
-  void * rmw_event,
+  rmw_event_t * rmw_event,
   bool use_previous_events);
 
 #ifdef __cplusplus

--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -207,6 +207,35 @@ typedef struct RMW_PUBLIC_TYPE rmw_guard_condition_t
   rmw_context_t * context;
 } rmw_guard_condition_t;
 
+/// Define publisher/subscription events
+typedef enum rmw_event_type_t
+{
+  // subscription events
+  RMW_EVENT_LIVELINESS_CHANGED,
+  RMW_EVENT_REQUESTED_DEADLINE_MISSED,
+  RMW_EVENT_REQUESTED_QOS_INCOMPATIBLE,
+  RMW_EVENT_MESSAGE_LOST,
+
+  // publisher events
+  RMW_EVENT_LIVELINESS_LOST,
+  RMW_EVENT_OFFERED_DEADLINE_MISSED,
+  RMW_EVENT_OFFERED_QOS_INCOMPATIBLE,
+
+  // sentinel value
+  RMW_EVENT_INVALID
+} rmw_event_type_t;
+
+/// Encapsulate the RMW event implementation, data, and type.
+typedef struct RMW_PUBLIC_TYPE rmw_event_t
+{
+  /// Implementation identifier, used to ensure two different implementations are not being mixed.
+  const char * implementation_identifier;
+  /// Data specific to this event type from either the publisher or subscriber.
+  void * data;
+  /// The event type that occurred.
+  rmw_event_type_t event_type;
+} rmw_event_t;
+
 /// Allocation of memory for an rmw publisher
 typedef struct RMW_PUBLIC_TYPE rmw_publisher_allocation_t
 {


### PR DESCRIPTION
* Use data types when setting callbacks
* Move some events definitions to where all the other entities definitions are, so `rmw.h` can recognize `rmw_event_t` data type